### PR TITLE
Be const-correct when passing char* pointers.

### DIFF
--- a/ArduinoNTPd/HTTPServer.cpp
+++ b/ArduinoNTPd/HTTPServer.cpp
@@ -83,7 +83,7 @@ bool HttpServer::processOneRequest()
     return processed;
 }
 
-void HttpServer::responseRedirect(char *url)
+void HttpServer::responseRedirect(const char *url)
 {
     currentClient_.println("HTTP/1.0 302 Found");
     currentClient_.print("Location: ");
@@ -129,7 +129,7 @@ void HttpServer::routeRequest_()
     }
 }
 
-void HttpServer::sendHttpResponseHeaders_(int code, char *description)
+void HttpServer::sendHttpResponseHeaders_(int code, const char *description)
 {
     currentClient_.print("HTTP/1.0 ");
     currentClient_.print(code, DEC);

--- a/ArduinoNTPd/HTTPServer.h
+++ b/ArduinoNTPd/HTTPServer.h
@@ -17,10 +17,10 @@ typedef void (*UrlHandlerFn)(HttpServer *server);
 
 struct UrlHandler
 {
-    UrlHandler(char *p, UrlHandlerFn fn)
+    UrlHandler(const char *p, UrlHandlerFn fn)
         : path(p), function(fn) { }
         
-    char *path;
+    const char *path;
     UrlHandlerFn function;
 };
 
@@ -50,7 +50,7 @@ public:
     /*
      * Redirects the user to a new URL.
      */
-    void responseRedirect(char *url);
+    void responseRedirect(const char *url);
     
     /*
      * Send OK response to client.
@@ -116,7 +116,7 @@ private:
     /*
      * Sends HTTP response headers to client.
      */
-    void sendHttpResponseHeaders_(int code, char *description);
+    void sendHttpResponseHeaders_(int code, const char *description);
 };
 
 #endif // HTTP_SERVER_H

--- a/ArduinoNTPd/NTPPacket.h
+++ b/ArduinoNTPd/NTPPacket.h
@@ -65,7 +65,7 @@ struct NtpPacket
     /*
      * Copies packet buffer to packet object.
      */
-    void populatePacket(char *buffer)
+    void populatePacket(const char *buffer)
     {
         memcpy(this, buffer, PACKET_SIZE);
     }


### PR DESCRIPTION
Fixes compiler warnings and is safer.